### PR TITLE
Add optional per-capture Telegram topics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 BRIDGE_TOKEN=            # generate: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 TELEGRAM_ENABLED=false   # flip to true after `python ringbearer.py login`
+NEW_TOPIC_PER_CAPTURE=false # true creates a fresh Telegram topic for every capture
 ASSISTANT_CHAT=          # @botusername (or chat id) of the Telegram DM your assistant lives in
 ASSISTANT_NAME=assistant # becomes the MCP tool name, e.g. Hermes -> send_to_hermes
 TG_API_ID=               # from https://my.telegram.org/apps

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ assistant, using its Telegram DM as the conversation surface.
 Double-click-hold the ring and speak. The Pebble app transcribes, its MCP
 sandbox agent calls this bridge's one tool, and the bridge posts your words
 into your existing Telegram DM with the assistant — **as you, from your own
-Telegram account**. The assistant sees a normal message in a thread it already
-knows, replies with full context, and the whole exchange stays auditable in
-Telegram like any other conversation. Start something from the ring on a walk,
-finish it on your phone later.
+Telegram account**. By default, the assistant sees a normal message in a
+thread it already knows and replies with full context. Optional per-capture
+topics start a fresh context instead. Either way, the whole exchange stays
+auditable in Telegram like any other conversation. Start something from the
+ring on a walk, finish it on your phone later.
 
 Works with any assistant that lives in a Telegram chat: Hermes, OpenClaw, a
 bot you wrote yourself. One Python file — FastAPI, the MCP SDK, Telethon.
+
+By default, captures continue in the current Telegram conversation. Set
+`NEW_TOPIC_PER_CAPTURE=true` to create a fresh topic for every capture instead.
+This optional mode is useful for assistants such as Hermes that keep separate
+context per Telegram topic.
 
 ## How it works
 
@@ -152,6 +158,10 @@ before you've done this, it refuses with exactly this fix named.
 - **The session file is your Telegram account.** `*.session` is gitignored;
   treat it like a password. One process per session file — a second client on
   the same session risks `AUTH_KEY_DUPLICATED` and revocation.
+- **New-topic mode has Telegram prerequisites.** The assistant bot must have
+  private-chat topics enabled and allow users to create topics. Telegram may
+  also require the sending user to have Premium. Topic creation fails closed:
+  ringbearer logs the capture instead of silently sending it to another topic.
 - **Probes are dry-run by default.** A live probe is a real message your real
   assistant will act on; `--live` is a deliberate flag for that reason.
 - **Captures are also logged locally.** Every transcript is appended verbatim
@@ -179,6 +189,7 @@ already set when the server starts (as the Docker image does for
 |---|---|
 | `BRIDGE_TOKEN` | Bearer token the phone must send (setup generates one) |
 | `TELEGRAM_ENABLED` | `true` to actually deliver; `false` = log-only mode |
+| `NEW_TOPIC_PER_CAPTURE` | `true` creates a fresh Telegram topic for every capture (default `false`) |
 | `ASSISTANT_CHAT` | `@botusername` of the assistant DM (recommended; a numeric chat id works only for chats this account's session has already seen — the server verifies at startup) |
 | `ASSISTANT_NAME` | Display name; becomes the tool name (`Hermes` → `send_to_hermes`) |
 | `TG_API_ID` / `TG_API_HASH` | Telegram API credentials (my.telegram.org) |

--- a/ringbearer.py
+++ b/ringbearer.py
@@ -112,6 +112,9 @@ def cyan(s: str) -> str:
 
 BRIDGE_TOKEN = os.environ.get("BRIDGE_TOKEN", "")
 TELEGRAM_ENABLED = os.environ.get("TELEGRAM_ENABLED", "false").lower() == "true"
+NEW_TOPIC_PER_CAPTURE = (
+    os.environ.get("NEW_TOPIC_PER_CAPTURE", "false").lower() == "true"
+)
 # @username, or a bare numeric chat id. A digits-only STRING gets resolved as
 # a phone number, so numeric ids are coerced to int. Numeric ids are best-
 # effort in Telethon — they resolve only from the session file's own entity
@@ -173,18 +176,54 @@ def log_capture(row: dict) -> None:
         f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
+def topic_title(message: str) -> str:
+    normalized = " ".join(message.split())
+    return normalized[:80] or "Ring capture"
+
+
+def delivery_mode_label() -> str:
+    if NEW_TOPIC_PER_CAPTURE:
+        return "new topic per capture"
+    return "current Telegram conversation"
+
+
+def created_topic_root_id(result) -> int | None:
+    from telethon.tl.types import MessageActionTopicCreate
+
+    for update in getattr(result, "updates", ()):
+        message = getattr(update, "message", None)
+        if isinstance(getattr(message, "action", None), MessageActionTopicCreate):
+            return getattr(message, "id", None)
+    return None
+
+
 async def deliver(message: str) -> bool:
     """Post into the assistant DM as the user. Returns True if actually sent."""
-    if TELEGRAM_ENABLED and tg_client is not None:
-        # parse_mode=None: the transcript is a promise ("verbatim and in
-        # full"), so *, _, ` and [] must arrive as characters, not formatting.
-        await tg_client.send_message(
-            assistant_entity if assistant_entity is not None else ASSISTANT_CHAT,
-            f"{RING_PREFIX}{message}",
-            parse_mode=None,
+    if not TELEGRAM_ENABLED or tg_client is None:
+        return False
+
+    entity = assistant_entity if assistant_entity is not None else ASSISTANT_CHAT
+    send_kwargs = {}
+    if NEW_TOPIC_PER_CAPTURE:
+        from telethon.tl.functions.messages import CreateForumTopicRequest
+
+        result = await tg_client(
+            CreateForumTopicRequest(peer=entity, title=topic_title(message))
         )
-        return True
-    return False
+        topic_root_id = created_topic_root_id(result)
+        if topic_root_id is None:
+            raise RuntimeError("Telegram topic creation returned no topic root message")
+        send_kwargs["reply_to"] = topic_root_id
+
+    # parse_mode=None: the transcript is a promise ("verbatim and in
+    # full"), so *, _, ` and [] must arrive as characters, not formatting.
+    await tg_client.send_message(
+        entity,
+        f"{RING_PREFIX}{message}",
+        parse_mode=None,
+        **send_kwargs,
+    )
+    return True
 
 
 # --- MCP server ---------------------------------------------------------------
@@ -548,6 +587,7 @@ def setup() -> None:
     env_path.write_text(
         f"BRIDGE_TOKEN={token}\n"
         "TELEGRAM_ENABLED=true\n"
+        "NEW_TOPIC_PER_CAPTURE=false\n"
         f"ASSISTANT_CHAT={chat}\n"
         f"ASSISTANT_NAME={name}\n"
         f"TG_API_ID={api_id}\n"
@@ -604,6 +644,7 @@ def print_phone_settings(host: str, port: str, token: str) -> None:
         print(dim("   the host address you published the port on)"))
     print(f"  URL:     {yellow(f'http://{host}:{port}{MCP_MOUNT}/mcp')}   (transport: Streamable)")
     print(f"  Header:  {yellow(f'Authorization: Bearer {token}')}")
+    print(f"  Delivery: {delivery_mode_label()}")
     print("  Name:    anything " + bold("WITHOUT spaces") + " (a space breaks tool dispatch)")
     print("  Group:   model type Default, then Secondary Mode → MCP Sandbox → pick the group.")
 
@@ -628,6 +669,7 @@ def run() -> None:
     import uvicorn
 
     print(bold(f"ringbearer → http://{BIND_HOST}:{BIND_PORT}{MCP_MOUNT}/mcp"))
+    print(f"Telegram delivery: {delivery_mode_label()}")
     if not TELEGRAM_ENABLED:
         print(
             yellow(

--- a/tests/test_topic_delivery.py
+++ b/tests/test_topic_delivery.py
@@ -1,0 +1,153 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from telethon.tl.functions.messages import CreateForumTopicRequest
+from telethon.tl.types import MessageActionTopicCreate
+
+import ringbearer
+
+
+class FakeTelegramClient:
+    def __init__(self, *, topic_id=42, create_error=None, send_error=None):
+        self.topic_id = topic_id
+        self.create_error = create_error
+        self.send_error = send_error
+        self.requests = []
+        self.sent = []
+
+    async def __call__(self, request):
+        self.requests.append(request)
+        if self.create_error:
+            raise self.create_error
+        message = SimpleNamespace(
+            id=self.topic_id,
+            action=MessageActionTopicCreate(title=request.title, icon_color=0x6FB9F0),
+        )
+        return SimpleNamespace(updates=[SimpleNamespace(message=message)])
+
+    async def send_message(self, entity, text, **kwargs):
+        self.sent.append((entity, text, kwargs))
+        if self.send_error:
+            raise self.send_error
+
+
+class TopicTitleTests(unittest.TestCase):
+    def test_normalizes_and_truncates_title(self):
+        message = "  hello\n\tworld  " + "x" * 100
+        title = ringbearer.topic_title(message)
+        self.assertEqual(title[:11], "hello world")
+        self.assertEqual(len(title), 80)
+
+    def test_empty_title_uses_fallback(self):
+        self.assertEqual(ringbearer.topic_title(" \n\t "), "Ring capture")
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_delivery_mode_label_describes_topic_mode(self):
+        with patch.object(ringbearer, "NEW_TOPIC_PER_CAPTURE", True):
+            self.assertEqual(ringbearer.delivery_mode_label(), "new topic per capture")
+
+    def test_delivery_mode_label_describes_direct_mode(self):
+        with patch.object(ringbearer, "NEW_TOPIC_PER_CAPTURE", False):
+            self.assertEqual(
+                ringbearer.delivery_mode_label(), "current Telegram conversation"
+            )
+
+
+class DeliveryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dry_probe_never_calls_delivery(self):
+        deliver = AsyncMock()
+        with (
+            patch.object(ringbearer, "deliver", deliver),
+            patch.object(ringbearer, "log_capture"),
+            patch("builtins.print"),
+        ):
+            result = await ringbearer.send_to_assistant(
+                f"{ringbearer.DRY_RUN_PREFIX} bridge probe"
+            )
+        deliver.assert_not_awaited()
+        self.assertEqual(result, "Dry run: received, not delivered to Telegram.")
+
+    async def test_direct_delivery_remains_default(self):
+        client = FakeTelegramClient()
+        entity = object()
+        with patch.multiple(
+            ringbearer,
+            TELEGRAM_ENABLED=True,
+            NEW_TOPIC_PER_CAPTURE=False,
+            RING_PREFIX="mic: ",
+            tg_client=client,
+            assistant_entity=entity,
+        ):
+            self.assertTrue(await ringbearer.deliver("hello"))
+        self.assertEqual(client.requests, [])
+        self.assertEqual(
+            client.sent,
+            [(entity, "mic: hello", {"parse_mode": None})],
+        )
+
+    async def test_topic_delivery_creates_then_replies_to_topic_root(self):
+        client = FakeTelegramClient(topic_id=99)
+        entity = object()
+        with patch.multiple(
+            ringbearer,
+            TELEGRAM_ENABLED=True,
+            NEW_TOPIC_PER_CAPTURE=True,
+            RING_PREFIX="mic: ",
+            tg_client=client,
+            assistant_entity=entity,
+        ):
+            self.assertTrue(await ringbearer.deliver("hello world"))
+
+        self.assertEqual(len(client.requests), 1)
+        request = client.requests[0]
+        self.assertIsInstance(request, CreateForumTopicRequest)
+        self.assertIs(request.peer, entity)
+        self.assertEqual(request.title, "hello world")
+        self.assertEqual(
+            client.sent,
+            [(entity, "mic: hello world", {"parse_mode": None, "reply_to": 99})],
+        )
+
+    async def test_topic_creation_failure_does_not_fallback(self):
+        client = FakeTelegramClient(create_error=RuntimeError("no topics"))
+        with patch.multiple(
+            ringbearer,
+            TELEGRAM_ENABLED=True,
+            NEW_TOPIC_PER_CAPTURE=True,
+            tg_client=client,
+            assistant_entity=object(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "no topics"):
+                await ringbearer.deliver("hello")
+        self.assertEqual(client.sent, [])
+
+    async def test_missing_topic_root_does_not_fallback(self):
+        client = FakeTelegramClient(topic_id=None)
+        with patch.multiple(
+            ringbearer,
+            TELEGRAM_ENABLED=True,
+            NEW_TOPIC_PER_CAPTURE=True,
+            tg_client=client,
+            assistant_entity=object(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "topic root"):
+                await ringbearer.deliver("hello")
+        self.assertEqual(client.sent, [])
+
+    async def test_threaded_send_failure_is_exposed(self):
+        client = FakeTelegramClient(send_error=RuntimeError("send failed"))
+        with patch.multiple(
+            ringbearer,
+            TELEGRAM_ENABLED=True,
+            NEW_TOPIC_PER_CAPTURE=True,
+            tg_client=client,
+            assistant_entity=object(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "send failed"):
+                await ringbearer.deliver("hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add opt-in `NEW_TOPIC_PER_CAPTURE=true` delivery that creates a fresh Telegram topic before sending each capture
- use Telethon's native raw `CreateForumTopicRequest`, then reply to the returned topic root message
- preserve the existing direct-delivery behavior by default
- fail closed if topic creation, root-message extraction, or threaded delivery fails
- document prerequisites and configuration

## Why

Forum-enabled assistant bots such as Hermes can keep independent context per Telegram topic. A normal user-account `send_message` lands in the current/recent topic, so ringbearer must create a topic and explicitly target its root message to start fresh context from the ring.

## Validation

- 10 offline unit tests on Python 3.11 and Python 3.13
- Python compilation and dependency consistency checks
- Docker Compose validation and image build
- dry probes remain side-effect-free

The option defaults to `false`, so existing `.env` files and delivery behavior remain compatible.