### PR TITLE
Add minimal Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+!ringbearer.py
+!requirements.txt
+!.env.example

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ Verify without touching your real DM:
 
 `probe` connects exactly like the phone would (same transport, same auth), so
 it bisects failures: probe succeeds → fix your phone settings; probe fails →
-fix server, network, or token. Set `BRIDGE_URL` to probe a remote install.
+fix server, network, or token. Set `BRIDGE_URL` to probe a remote install —
+and note the probe takes its token and tool name from the local config, so
+when the target runs different settings (a container, another machine), point
+`RINGBEARER_STATE_DIR` at that install's state directory too.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ if it lands, this gets even simpler.
 ## Configuration
 
 Configuration comes from the process environment and `.env` (see
-[`.env.example`](.env.example)):
+[`.env.example`](.env.example)). The process environment wins: a variable
+already set when the server starts (as the Docker image does for
+`BIND_HOST`/`BIND_PORT`) is not overridden by the same key in `.env`:
 
 | Variable | Meaning |
 |---|---|
@@ -181,7 +183,7 @@ Configuration comes from the process environment and `.env` (see
 | `SESSION_NAME` | Telegram session file name (default `ringbearer`) |
 | `RING_PREFIX` | Prefix on relayed messages (default 🎤) |
 | `MCP_MOUNT` | Mount path; endpoint is `<MCP_MOUNT>/mcp` (default `/ringbearer`) |
-| `RINGBEARER_STATE_DIR` | Directory for `.env`, Telegram session files, and captures (process environment only; defaults to this checkout) |
+| `RINGBEARER_STATE_DIR` | Absolute directory for `.env`, Telegram session files, and captures (process environment only; defaults to this checkout). `service` bakes it into the launchd plist. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Verify without touching your real DM:
 it bisects failures: probe succeeds → fix your phone settings; probe fails →
 fix server, network, or token. Set `BRIDGE_URL` to probe a remote install.
 
+## Docker
+
+Docker support keeps the image disposable and all private state in one
+bind-mounted directory. See [`docker/README.md`](docker/README.md) for the
+minimal image, Compose example, interactive Telegram login, and deliberate
+Tailscale/LAN binding.
+
 ## Phone settings (Pebble app)
 
 Under Index settings → MCP servers:
@@ -160,7 +167,8 @@ if it lands, this gets even simpler.
 
 ## Configuration
 
-All via `.env` (see [`.env.example`](.env.example)):
+Configuration comes from the process environment and `.env` (see
+[`.env.example`](.env.example)):
 
 | Variable | Meaning |
 |---|---|
@@ -173,6 +181,7 @@ All via `.env` (see [`.env.example`](.env.example)):
 | `SESSION_NAME` | Telegram session file name (default `ringbearer`) |
 | `RING_PREFIX` | Prefix on relayed messages (default 🎤) |
 | `MCP_MOUNT` | Mount path; endpoint is `<MCP_MOUNT>/mcp` (default `/ringbearer`) |
+| `RINGBEARER_STATE_DIR` | Directory for `.env`, Telegram session files, and captures (process environment only; defaults to this checkout) |
 
 ## License
 

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+data/
+compose.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    RINGBEARER_STATE_DIR=/data \
+    BIND_HOST=0.0.0.0 \
+    BIND_PORT=8787
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ringbearer.py .env.example ./
+
+RUN useradd --create-home --uid 1000 ringbearer \
+    && mkdir /data \
+    && chown ringbearer:ringbearer /data
+
+USER ringbearer
+EXPOSE 8787
+
+ENTRYPOINT ["python", "/app/ringbearer.py"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,4 +1,0 @@
-**
-!ringbearer.py
-!requirements.txt
-!.env.example

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+**
+!ringbearer.py
+!requirements.txt
+!.env.example

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Docker
 
-Ringbearer's image contains the application. Configuration, the Telegram
+ringbearer's image contains the application. Configuration, the Telegram
 session, and captured transcripts stay in the bind-mounted `data/` directory.
 
 ## Setup
@@ -30,10 +30,9 @@ reachable from other machines on the same local network segment, and on all
 versions Docker's published ports bypass ufw/firewalld rules. The Tailscale
 binding avoids both.
 
-The build keeps your private state out of the build context via
-`Dockerfile.dockerignore`, which only BuildKit honors — the default builder
-since Docker 23. Don't build this with a legacy builder: it would send your
-whole checkout, private state included, to the Docker daemon.
+The repo-root `.dockerignore` whitelists only the three files the image
+needs, so your private state never reaches the Docker daemon as build
+context, on any builder.
 
 Run onboarding inside the container:
 
@@ -80,7 +79,7 @@ from the public internet.
 
 To migrate an existing native installation, stop it first, then copy `.env`,
 all `<SESSION_NAME>.session*` files, and `captures.jsonl` into `docker/data/`.
-Never run native and containerized Ringbearer against the same Telegram
+Never run native and containerized ringbearer against the same Telegram
 session simultaneously.
 
 Deployment systems may render their own `.env` and mount any persistent

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,89 @@
+# Docker
+
+Ringbearer's image contains the application. Configuration, the Telegram
+session, and captured transcripts stay in the bind-mounted `data/` directory.
+
+## Setup
+
+From the repository root:
+
+```bash
+cp docker/compose.example.yml docker/compose.yml
+mkdir -p docker/data
+```
+
+The image runs as UID 1000. On Linux, if your user has a different UID, give
+only this new state directory to the container user before onboarding:
+
+```bash
+sudo chown -R 1000:1000 docker/data
+```
+
+Docker Desktop handles bind-mounted ownership on macOS, so this step is not
+normally needed there.
+
+Edit `docker/compose.yml` or set `RINGBEARER_HOST` to the Docker host interface
+that Pebble should reach. A Tailscale `100.x.x.x` address is recommended. The
+checked-in default, `127.0.0.1`, is intentionally reachable only on the host.
+
+Run onboarding inside the container:
+
+```bash
+docker compose -f docker/compose.yml run --rm --service-ports ringbearer
+```
+
+Enter `0.0.0.0` for `BIND_HOST`: that is the listener inside the container.
+Configure Pebble with the host address selected above, not `0.0.0.0`. Setup
+writes `.env`, the Telegram login writes `ringbearer.session`, and delivery
+writes `captures.jsonl`; all remain under `docker/data/`.
+
+Test the foreground bridge, press Ctrl-C, then start it in the background:
+
+```bash
+docker compose -f docker/compose.yml up -d
+```
+
+## Operations
+
+```bash
+docker compose -f docker/compose.yml logs -f
+docker compose -f docker/compose.yml ps
+docker compose -f docker/compose.yml down
+docker compose -f docker/compose.yml build --pull
+docker compose -f docker/compose.yml up -d
+```
+
+## Network exposure
+
+Bind the published port to the host's Tailscale address when possible:
+
+```yaml
+ports:
+  - "100.64.0.1:8787:8787" # replace with this host's Tailscale IP
+```
+
+A LAN address works only on that LAN and exposes the port to that network.
+Do not omit the host IP, bind the host side to `0.0.0.0`, or forward this port
+from the public internet.
+
+## Existing state and deployment systems
+
+To migrate an existing native installation, stop it first, then copy `.env`
+and all `<SESSION_NAME>.session*` files into `docker/data/`. Never run native
+and containerized Ringbearer against the same Telegram session simultaneously.
+
+Deployment systems may render their own `.env` and mount any persistent
+directory at `/data`; Compose is only an example.
+
+The session file grants access to your Telegram account; protect the entire
+state directory like a password. The bearer token gates MCP calls but does not
+make public-internet exposure safe.
+
+## Troubleshooting
+
+- Permission denied under `/data`: apply the narrowly scoped ownership command
+  from Setup, then retry onboarding.
+- Healthy but unreachable: replace the loopback publication with the host's
+  Tailscale or LAN address and use that same address in Pebble.
+- Port binding failure: confirm the selected address exists on the Docker host.
+- Missing session: rerun the interactive container and complete Telegram login.

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,11 @@ Edit `docker/compose.yml` or set `RINGBEARER_HOST` to the Docker host interface
 that Pebble should reach. A Tailscale `100.x.x.x` address is recommended. The
 checked-in default, `127.0.0.1`, is intentionally reachable only on the host.
 
+The build keeps your private state out of the build context via
+`Dockerfile.dockerignore`, which only BuildKit honors — the default builder
+since Docker 23. Don't build this with a legacy builder: it would send your
+whole checkout, private state included, to the Docker daemon.
+
 Run onboarding inside the container:
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,7 +24,11 @@ normally needed there.
 
 Edit `docker/compose.yml` or set `RINGBEARER_HOST` to the Docker host interface
 that Pebble should reach. A Tailscale `100.x.x.x` address is recommended. The
-checked-in default, `127.0.0.1`, is intentionally reachable only on the host.
+checked-in default, `127.0.0.1`, keeps the port host-only in most setups — but
+on Linux with Docker Engine older than 28, loopback-published ports were
+reachable from other machines on the same local network segment, and on all
+versions Docker's published ports bypass ufw/firewalld rules. The Tailscale
+binding avoids both.
 
 The build keeps your private state out of the build context via
 `Dockerfile.dockerignore`, which only BuildKit honors — the default builder
@@ -37,10 +41,11 @@ Run onboarding inside the container:
 docker compose -f docker/compose.yml run --rm --service-ports ringbearer
 ```
 
-Enter `0.0.0.0` for `BIND_HOST`: that is the listener inside the container.
-Configure Pebble with the host address selected above, not `0.0.0.0`. Setup
-writes `.env`, the Telegram login writes `ringbearer.session`, and delivery
-writes `captures.jsonl`; all remain under `docker/data/`.
+Setup takes the listen address from the container's environment (`0.0.0.0`,
+the listener inside the container) and skips that question. Configure Pebble
+with the host address selected above, not `0.0.0.0`. Setup writes `.env`, the
+Telegram login writes `ringbearer.session`, and delivery writes
+`captures.jsonl`; all remain under `docker/data/`.
 
 Test the foreground bridge, press Ctrl-C, then start it in the background:
 
@@ -73,9 +78,10 @@ from the public internet.
 
 ## Existing state and deployment systems
 
-To migrate an existing native installation, stop it first, then copy `.env`
-and all `<SESSION_NAME>.session*` files into `docker/data/`. Never run native
-and containerized Ringbearer against the same Telegram session simultaneously.
+To migrate an existing native installation, stop it first, then copy `.env`,
+all `<SESSION_NAME>.session*` files, and `captures.jsonl` into `docker/data/`.
+Never run native and containerized Ringbearer against the same Telegram
+session simultaneously.
 
 Deployment systems may render their own `.env` and mount any persistent
 directory at `/data`; Compose is only an example.
@@ -87,7 +93,12 @@ make public-internet exposure safe.
 ## Troubleshooting
 
 - Permission denied under `/data`: apply the narrowly scoped ownership command
-  from Setup, then retry onboarding.
+  from Setup, then retry onboarding. On SELinux-enforcing hosts (Fedora/RHEL),
+  also add `:Z` to the volume line: `./data:/data:Z` — ownership alone won't
+  clear a label denial.
+- Container restarts repeatedly with "No .env yet" in the logs: you ran
+  `up -d` before onboarding. Run the interactive onboarding command from
+  Setup first.
 - Healthy but unreachable: replace the loopback publication with the host's
   Tailscale or LAN address and use that same address in Pebble.
 - Port binding failure: confirm the selected address exists on the Docker host.

--- a/docker/compose.example.yml
+++ b/docker/compose.example.yml
@@ -1,8 +1,15 @@
+# Without an explicit name, the project would be named after this directory
+# ("docker") and collide with any other repo doing the same.
+name: ringbearer
+
 services:
   ringbearer:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    # The container always listens on 8787; to change the outside port,
+    # remap the HOST side of `ports:` below. Changing BIND_PORT instead
+    # would break the healthcheck, which probes 8787 inside the container.
     environment:
       BIND_HOST: 0.0.0.0
       BIND_PORT: 8787

--- a/docker/compose.example.yml
+++ b/docker/compose.example.yml
@@ -1,0 +1,27 @@
+services:
+  ringbearer:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      BIND_HOST: 0.0.0.0
+      BIND_PORT: 8787
+    # Recommended: set RINGBEARER_HOST to this machine's Tailscale
+    # 100.x.x.x address. The default is reachable only from this host.
+    ports:
+      - "${RINGBEARER_HOST:-127.0.0.1}:8787:8787"
+    volumes:
+      - ./data:/data
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.urlopen('http://127.0.0.1:8787/healthz', timeout=2)
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s

--- a/ringbearer.py
+++ b/ringbearer.py
@@ -71,8 +71,13 @@ HERE = Path(__file__).parent
 # RINGBEARER_STATE_DIR when set — the seam that keeps a Docker image
 # disposable while user data persists. Unset, it IS the checkout, and nothing
 # changes for native installs. Process environment only, never .env: this
-# value decides where .env is.
-STATE_DIR = Path(os.environ.get("RINGBEARER_STATE_DIR", HERE)).expanduser().resolve()
+# value decides where .env is. Must be absolute — a relative path would move
+# with the launching directory, silently splitting state between cwds; empty
+# means unset, not cwd.
+_state_raw = os.environ.get("RINGBEARER_STATE_DIR", "").strip()
+if _state_raw and not Path(_state_raw).expanduser().is_absolute():
+    sys.exit(f"RINGBEARER_STATE_DIR must be an absolute path (got: {_state_raw!r})")
+STATE_DIR = (Path(_state_raw).expanduser() if _state_raw else HERE).resolve()
 load_dotenv(STATE_DIR / ".env")
 
 CAPTURES = STATE_DIR / "captures.jsonl"
@@ -128,6 +133,10 @@ SESSION_NAME = os.environ.get("SESSION_NAME", "ringbearer")
 # chmod (checks would look for name.session.session). Normalize once here.
 if SESSION_NAME.endswith(".session"):
     SESSION_NAME = SESSION_NAME[: -len(".session")]
+# A bare file name only: a separator or dot-dot would silently escape
+# STATE_DIR's containment promise (Path("/data") / "/tmp/x" IS /tmp/x).
+if "/" in SESSION_NAME or SESSION_NAME in ("", ".", ".."):
+    sys.exit(f"SESSION_NAME must be a bare file name, not a path (got: {SESSION_NAME!r})")
 MCP_MOUNT = os.environ.get("MCP_MOUNT", "/ringbearer")
 BIND_HOST = os.environ.get("BIND_HOST", "")
 try:
@@ -429,6 +438,7 @@ def login() -> None:
         # Pre-create the session file owner-only: Telethon would otherwise
         # create it at the umask default, leaving the account-bearing file
         # world-readable for the whole interactive window below.
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
         (STATE_DIR / f"{SESSION_NAME}.session").touch(mode=0o600, exist_ok=True)
         # Client construction and use stay inside one event loop — Telethon
         # binds the client to the loop it was created under. Construction
@@ -505,24 +515,33 @@ def setup() -> None:
     print("   (e.g. 'Hermes' -> send_to_hermes):")
     name = ask("     ASSISTANT_NAME [assistant]: ", default="assistant")
 
-    print("\n" + cyan("5. Where should the server listen?") + " Give the IP your phone can reach")
-    print("   this machine at:")
-    print("   - Tailscale IP (100.x.x.x) — recommended: works from anywhere, and")
-    print("     the port is never visible to your LAN or the internet.")
-    print("   - LAN IP (192.168.x.x) — works, but only while your phone is on the")
-    print("     same network, and anyone on that network can reach the port.")
-    print("   Never expose this to the public internet.")
-    while True:
-        host = ask("     BIND_HOST: ")
-        try:
-            _s = socket.socket()
-            _s.bind((host, 0))
-            _s.close()
-            break
-        except OSError:
-            print(dim("     (this machine can't bind that address — is Tailscale up?"))
-            print(dim("      `ifconfig` shows what's available)"))
-    port = ask("     BIND_PORT [8787]: ", default="8787", numeric=True)
+    # A container (or any wrapper) bakes BIND_HOST/BIND_PORT into the process
+    # environment, and the environment beats .env at runtime — asking here
+    # would collect an answer that could never take effect. Skip the question
+    # and say where the values came from.
+    if os.environ.get("BIND_HOST"):
+        host = os.environ["BIND_HOST"]
+        port = os.environ.get("BIND_PORT", "8787")
+        print("\n" + cyan("5. Listen address") + f" — already set by the environment: {host}:{port}")
+    else:
+        print("\n" + cyan("5. Where should the server listen?") + " Give the IP your phone can reach")
+        print("   this machine at:")
+        print("   - Tailscale IP (100.x.x.x) — recommended: works from anywhere, and")
+        print("     the port is never visible to your LAN or the internet.")
+        print("   - LAN IP (192.168.x.x) — works, but only while your phone is on the")
+        print("     same network, and anyone on that network can reach the port.")
+        print("   Never expose this to the public internet.")
+        while True:
+            host = ask("     BIND_HOST: ")
+            try:
+                _s = socket.socket()
+                _s.bind((host, 0))
+                _s.close()
+                break
+            except OSError:
+                print(dim("     (this machine can't bind that address — is Tailscale up?"))
+                print(dim("      `ifconfig` shows what's available)"))
+        port = ask("     BIND_PORT [8787]: ", default="8787", numeric=True)
 
     # Restricted from birth: no umask-default window with the token inside.
     env_path.touch(mode=0o600)
@@ -577,6 +596,12 @@ def check_bindable(host: str) -> None:
 def print_phone_settings(host: str, port: str, token: str) -> None:
     print(bold("\nPebble app settings") + " (Index settings → MCP servers)")
     print(dim("  — reprint any time with `python ringbearer.py setup`"))
+    if host == "0.0.0.0":
+        # The listener answers on every interface, but the phone needs a real
+        # address to dial — in Docker, the address the port is published on.
+        host = "<this-machine's-address>"
+        print(dim("  (0.0.0.0 is the listener, not a dialable address — in Docker, use"))
+        print(dim("   the host address you published the port on)"))
     print(f"  URL:     {yellow(f'http://{host}:{port}{MCP_MOUNT}/mcp')}   (transport: Streamable)")
     print(f"  Header:  {yellow(f'Authorization: Bearer {token}')}")
     print("  Name:    anything " + bold("WITHOUT spaces") + " (a space breaks tool dispatch)")
@@ -660,6 +685,17 @@ def render_plist(label: str) -> str:
     if not python.exists():
         python = Path(sys.executable)
     logs = HERE / "logs"
+    # launchd does NOT inherit the installing shell's environment: without
+    # this block a custom RINGBEARER_STATE_DIR would silently revert to the
+    # checkout inside the agent — no .env found, KeepAlive crash loop.
+    env_block = ""
+    if STATE_DIR != HERE.resolve():
+        env_block = f"""    <key>EnvironmentVariables</key>
+    <dict>
+        <key>RINGBEARER_STATE_DIR</key>
+        <string>{STATE_DIR}</string>
+    </dict>
+"""
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -674,7 +710,7 @@ def render_plist(label: str) -> str:
     </array>
     <key>WorkingDirectory</key>
     <string>{HERE}</string>
-    <key>RunAtLoad</key>
+{env_block}    <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
@@ -713,11 +749,12 @@ def service(uninstall: bool = False) -> None:
         return
 
     for blocked in ("Documents", "Desktop", "Downloads"):
-        if Path.home() / blocked in HERE.parents:
-            sys.exit(
-                f"This checkout lives under ~/{blocked}, which launchd agents can't read\n"
-                "(macOS TCC). Move it somewhere like ~/Projects and rerun."
-            )
+        for d, what in ((HERE.resolve(), "checkout"), (STATE_DIR, "state directory")):
+            if Path.home() / blocked in d.parents:
+                sys.exit(
+                    f"The {what} lives under ~/{blocked}, which launchd agents can't read\n"
+                    "(macOS TCC). Move it somewhere like ~/Projects and rerun."
+                )
     missing = required_missing()
     if missing:
         incomplete_env_exit(missing)
@@ -823,3 +860,9 @@ if __name__ == "__main__":
             print(__doc__)
     except (EOFError, KeyboardInterrupt):
         sys.exit("\nCancelled. Rerun `python ringbearer.py` when ready.")
+    except PermissionError as e:
+        sys.exit(
+            f"Permission denied: {e}\n"
+            f"Can this user write {STATE_DIR}? In Docker, see docker/README.md "
+            "→ Troubleshooting (bind-mount ownership)."
+        )

--- a/ringbearer.py
+++ b/ringbearer.py
@@ -833,9 +833,16 @@ def first_run(fresh: bool = False) -> None:
         # to graduate it to a real service.
         print(bold("Starting the server in THIS terminal") + " so you can watch it work —")
         print("double-click your ring and the tool call will log below. Ctrl-C stops it.")
-        print("To run it permanently as a background service instead (macOS, one command):")
-        print("  " + bold("python ringbearer.py service"))
-        print(dim("(Details: README → Running it as a service.)\n"))
+        # The graduation advice depends on where this is running: `service` is
+        # launchd and only exists on a Mac — in a container or on Linux it
+        # would just be a dead end printed at the moment of success.
+        print("To run it permanently in the background instead:")
+        if sys.platform == "darwin":
+            print("  " + bold("python ringbearer.py service") + "   (macOS, one command)")
+        else:
+            print("  Docker: Ctrl-C, then " + bold("docker compose -f docker/compose.yml up -d"))
+            print("  Linux (native): run `ringbearer.py run` under systemd")
+        print(dim("(Details: README → Running it as a service / Docker.)\n"))
     run()
 
 

--- a/ringbearer.py
+++ b/ringbearer.py
@@ -66,10 +66,16 @@ import logging
 logging.getLogger("telethon").setLevel(logging.WARNING)
 logging.getLogger("mcp").setLevel(logging.WARNING)
 
-load_dotenv()
-
 HERE = Path(__file__).parent
-CAPTURES = HERE / "captures.jsonl"
+# Private mutable state (.env, the Telegram session, captures.jsonl) lives in
+# RINGBEARER_STATE_DIR when set — the seam that keeps a Docker image
+# disposable while user data persists. Unset, it IS the checkout, and nothing
+# changes for native installs. Process environment only, never .env: this
+# value decides where .env is.
+STATE_DIR = Path(os.environ.get("RINGBEARER_STATE_DIR", HERE)).expanduser().resolve()
+load_dotenv(STATE_DIR / ".env")
+
+CAPTURES = STATE_DIR / "captures.jsonl"
 DRY_RUN_PREFIX = "DRYRUN:"
 
 # Terminal color helpers — plain when piped or NO_COLOR is set.
@@ -114,7 +120,7 @@ ASSISTANT_NAME = os.environ.get("ASSISTANT_NAME", "assistant")
 RING_PREFIX = os.environ.get("RING_PREFIX", "\U0001f3a4 ")
 TG_API_ID = os.environ.get("TG_API_ID", "")
 if TG_API_ID and not TG_API_ID.isdigit():
-    sys.exit(f"TG_API_ID in .env is not a number — edit {HERE / '.env'}")
+    sys.exit(f"TG_API_ID in .env is not a number — edit {STATE_DIR / '.env'}")
 TG_API_HASH = os.environ.get("TG_API_HASH", "")
 SESSION_NAME = os.environ.get("SESSION_NAME", "ringbearer")
 # Telethon appends ".session" only when the name lacks it — a name already
@@ -127,7 +133,7 @@ BIND_HOST = os.environ.get("BIND_HOST", "")
 try:
     BIND_PORT = int(os.environ.get("BIND_PORT", "8787"))
 except ValueError:
-    sys.exit(f"BIND_PORT in .env is not a number — edit {HERE / '.env'}")
+    sys.exit(f"BIND_PORT in .env is not a number — edit {STATE_DIR / '.env'}")
 
 # The tool name the ring app's LLM sees, e.g. send_to_hermes. Keep it free of
 # anything but [a-z0-9_]: the app sanitizes names for the LLM but dispatches on
@@ -146,7 +152,7 @@ def make_tg_client():
     # `ringbearer.py login` always share one file no matter which directory
     # launched the process (uvicorn, launchd, a shell — all the same).
     return TelegramClient(
-        str(HERE / SESSION_NAME),
+        str(STATE_DIR / SESSION_NAME),
         int(TG_API_ID),
         TG_API_HASH,
     )
@@ -285,7 +291,7 @@ async def lifespan(app: FastAPI):
                 "TELEGRAM_ENABLED but TG_API_ID/TG_API_HASH/ASSISTANT_CHAT missing "
                 "— run: python ringbearer.py setup"
             )
-        if not (HERE / f"{SESSION_NAME}.session").exists():
+        if not (STATE_DIR / f"{SESSION_NAME}.session").exists():
             raise RuntimeError(
                 f"TELEGRAM_ENABLED but no {SESSION_NAME}.session found "
                 "— run: python ringbearer.py login"
@@ -349,7 +355,7 @@ async def lifespan(app: FastAPI):
                 f"{type(e).__name__}: {e}\n"
                 "A numeric id only works for chats this account has already "
                 "seen from this session; the @username form always works — "
-                f"set it in {HERE / '.env'}."
+                f"set it in {STATE_DIR / '.env'}."
             ) from e
     async with mcp.session_manager.run():
         yield
@@ -423,7 +429,7 @@ def login() -> None:
         # Pre-create the session file owner-only: Telethon would otherwise
         # create it at the umask default, leaving the account-bearing file
         # world-readable for the whole interactive window below.
-        (HERE / f"{SESSION_NAME}.session").touch(mode=0o600, exist_ok=True)
+        (STATE_DIR / f"{SESSION_NAME}.session").touch(mode=0o600, exist_ok=True)
         # Client construction and use stay inside one event loop — Telethon
         # binds the client to the loop it was created under. Construction
         # also OPENS the session DB: a Pyrogram-era file fails here.
@@ -445,7 +451,7 @@ def login() -> None:
     print(green(f"\nLogged in as {me.first_name} ({handle}) — session saved as {SESSION_NAME}.session"))
     # The session file IS the Telegram account — created at the umask default
     # (644); pull it to owner-only like .env and captures.jsonl.
-    for f in HERE.glob(f"{SESSION_NAME}.session*"):
+    for f in STATE_DIR.glob(f"{SESSION_NAME}.session*"):
         f.chmod(0o600)
 
 
@@ -453,7 +459,8 @@ def setup() -> None:
     """Interactive first-run walkthrough: collects every secret, writes .env."""
     import secrets
 
-    env_path = HERE / ".env"
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    env_path = STATE_DIR / ".env"
     if env_path.exists():
         print(f"{env_path} already exists — edit it directly, or delete it and rerun setup.")
         missing = [
@@ -563,7 +570,7 @@ def check_bindable(host: str) -> None:
         sys.exit(
             f"Can't bind {host} ({e.strerror or e}) — this machine doesn't hold that\n"
             "address right now. Is Tailscale up? `ifconfig` lists what's available;\n"
-            f"fix BIND_HOST in {HERE / '.env'}."
+            f"fix BIND_HOST in {STATE_DIR / '.env'}."
         )
 
 
@@ -579,7 +586,7 @@ def print_phone_settings(host: str, port: str, token: str) -> None:
 def incomplete_env_exit(missing: list[str]) -> None:
     sys.exit(
         f".env is incomplete — missing: {', '.join(missing)}.\n"
-        f"Edit {HERE / '.env'} (see .env.example), or delete it and rerun "
+        f"Edit {STATE_DIR / '.env'} (see .env.example), or delete it and rerun "
         "`python ringbearer.py` to redo setup."
     )
 
@@ -590,7 +597,7 @@ def run() -> None:
     missing = required_missing()
     if missing:
         incomplete_env_exit(missing)
-    if TELEGRAM_ENABLED and not (HERE / f"{SESSION_NAME}.session").exists():
+    if TELEGRAM_ENABLED and not (STATE_DIR / f"{SESSION_NAME}.session").exists():
         sys.exit(f"No {SESSION_NAME}.session — run: python ringbearer.py login")
     check_bindable(BIND_HOST)
     import uvicorn
@@ -714,7 +721,7 @@ def service(uninstall: bool = False) -> None:
     missing = required_missing()
     if missing:
         incomplete_env_exit(missing)
-    if TELEGRAM_ENABLED and not (HERE / f"{SESSION_NAME}.session").exists():
+    if TELEGRAM_ENABLED and not (STATE_DIR / f"{SESSION_NAME}.session").exists():
         sys.exit(f"No {SESSION_NAME}.session — run: python ringbearer.py login")
     check_bindable(BIND_HOST)
     s = socket.socket()
@@ -755,7 +762,7 @@ def service(uninstall: bool = False) -> None:
 def first_run(fresh: bool = False) -> None:
     """The whole onboarding as one loop: look at what exists on disk, collect
     what's missing, end with a running server. Safe to re-run forever."""
-    if not (HERE / ".env").exists():
+    if not (STATE_DIR / ".env").exists():
         if not sys.stdin.isatty():
             sys.exit(
                 "No .env yet, and no terminal to ask questions in — run "
@@ -772,7 +779,7 @@ def first_run(fresh: bool = False) -> None:
     if missing:
         incomplete_env_exit(missing)
     just_logged_in = False
-    if TELEGRAM_ENABLED and not (HERE / f"{SESSION_NAME}.session").exists():
+    if TELEGRAM_ENABLED and not (STATE_DIR / f"{SESSION_NAME}.session").exists():
         if not sys.stdin.isatty():
             sys.exit(f"No {SESSION_NAME}.session — run: python ringbearer.py login")
         print("One more thing: Telegram login.\n")


### PR DESCRIPTION
## Summary

- add a minimal Python 3.13 image and copyable Compose example under `docker/`
- keep `.env`, Telegram session files, and captures in one bind-mounted `/data` directory
- default host publication to loopback and document deliberate Tailscale/LAN exposure
- preserve existing native behavior through an opt-in `RINGBEARER_STATE_DIR`

## Why

The current service works well natively, but container deployments otherwise have to place private mutable state beside application code. This adds a small state-directory boundary so the image remains disposable while user data persists separately.

This is independent of #2. If #2 merges first, this branch can be rebased onto the updated `main` before review is finalized.

## Validation

- 8 unit tests pass
- Python compilation passes
- `docker compose -f docker/compose.example.yml config --quiet`
- Docker image builds from the restricted Dockerfile-specific context
- log-only container starts as the unprivileged `ringbearer` user and `/healthz` returns `{"ok":true,"telegram":false}`
- independent code review found no remaining critical, important, or minor issues
