### PR TITLE
feat: add one-shot delivery context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 BRIDGE_TOKEN=            # generate: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 TELEGRAM_ENABLED=false   # flip to true after `python ringbearer.py login`
 NEW_TOPIC_PER_CAPTURE=false # true creates a fresh Telegram topic for every capture
+DELIVERY_CONTEXT=conversation # one_shot tells the assistant to act without waiting for follow-up
 ASSISTANT_CHAT=          # @botusername (or chat id) of the Telegram DM your assistant lives in
 ASSISTANT_NAME=assistant # how the tool describes your assistant to the ring app's LLM (e.g. Hermes)
 TG_API_ID=               # from https://my.telegram.org/apps

--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ BotFather change (restart Telegram if you don't see it). Topic creation
 fails closed: ringbearer logs the capture instead of silently sending it to
 another topic.
 
+### One-shot ring context
+
+Normal chat assumes the user can read a reply and answer a follow-up question.
+That assumption is wrong when they are walking around speaking into a ring. Set:
+
+```env
+DELIVERY_CONTEXT=one_shot
+```
+
+Ringbearer then wraps the verbatim transcript in a short recipient-side
+instruction explaining that the user may not see the reply. An actionable
+request is treated as authorization to act now: the assistant should not ask
+for confirmation, should resolve minor ambiguity with reasonable low-risk
+defaults, and should report the result briefly. If essential information is
+missing, or an action would be materially unsafe or irreversible, it should
+leave a concise blocker rather than inventing details or waiting for a live
+answer.
+
+The default is `conversation`, which preserves the historical message shape
+and normal back-and-forth behaviour. This setting changes only what the target
+assistant receives. Captures remain logged verbatim, topic titles still use
+the raw transcript, and the Pebble cloud agent remains a relay rather than an
+executor.
+
 ## Multiple assistants
 
 One bridge can carry to more than one assistant. Map the extras in `.env`:
@@ -258,6 +282,7 @@ already set when the server starts (as the Docker image does for
 | `BRIDGE_TOKEN` | Bearer token the phone must send (setup generates one) |
 | `TELEGRAM_ENABLED` | `true` to actually deliver; `false` = log-only mode |
 | `NEW_TOPIC_PER_CAPTURE` | `true` creates a fresh Telegram topic for every capture (default `false`) |
+| `DELIVERY_CONTEXT` | Recipient-side handling contract: `conversation` preserves normal chat; `one_shot` tells the assistant to act without waiting for follow-up (default `conversation`) |
 | `ASSISTANT_CHAT` | `@botusername` of the assistant DM (recommended; a numeric chat id works only for chats this account's session has already seen — the server verifies at startup) |
 | `ASSISTANT_NAME` | Display name the tool description and acks use (`Hermes`); also names the default in the `assistant` enum |
 | `ASSISTANTS` | Optional extra assistants, `name:chat` pairs (`plutus:@plutus_bot,qm:@qm_bot`) — adds an `assistant` argument to the tool; see [Multiple assistants](#multiple-assistants) |

--- a/ringbearer.py
+++ b/ringbearer.py
@@ -129,6 +129,12 @@ _chat = os.environ.get("ASSISTANT_CHAT", "")
 ASSISTANT_CHAT = int(_chat) if re.fullmatch(r"-?\d+", _chat) else _chat
 ASSISTANT_NAME = os.environ.get("ASSISTANT_NAME", "assistant")
 RING_PREFIX = os.environ.get("RING_PREFIX", "\U0001f3a4 ")
+DELIVERY_CONTEXT = os.environ.get("DELIVERY_CONTEXT", "conversation").lower()
+if DELIVERY_CONTEXT not in {"conversation", "one_shot"}:
+    sys.exit(
+        "DELIVERY_CONTEXT must be 'conversation' or 'one_shot' "
+        f"(got: {DELIVERY_CONTEXT!r})"
+    )
 TG_API_ID = os.environ.get("TG_API_ID", "")
 if TG_API_ID and not TG_API_ID.isdigit():
     sys.exit(f"TG_API_ID in .env is not a number — edit {STATE_DIR / '.env'}")
@@ -459,6 +465,24 @@ def delivery_mode_label() -> str:
     return "current Telegram conversation"
 
 
+def format_delivery_message(message: str) -> str:
+    """Add recipient-side context without changing the captured transcript."""
+    if DELIVERY_CONTEXT == "conversation":
+        return f"{RING_PREFIX}{message}"
+    return (
+        f"{RING_PREFIX}[RING CAPTURE: ONE-SHOT]\n"
+        "The user is speaking through an Index 01 ring and may not see any reply. "
+        "If this message requests an action, treat the spoken request as "
+        "authorization and execute it now without asking for confirmation. "
+        "Resolve minor ambiguity using reasonable, low-risk defaults and known "
+        "context. If essential information is unavailable, or the action would "
+        "be materially unsafe or irreversible, do not invent it; leave a concise "
+        "blocker for the user to find later. Report the outcome briefly after "
+        "attempting the action.\n\n"
+        f"Transcript:\n{message}"
+    )
+
+
 async def create_topic(title: str, peer) -> int:
     """Create a fresh topic in `peer`'s chat and return its topic id.
 
@@ -522,7 +546,7 @@ async def deliver(message: str, assistant: str | None = None) -> bool:
     # send into that topic; None is Telethon's default (no threading).
     await tg_client.send_message(
         target,
-        f"{RING_PREFIX}{message}",
+        format_delivery_message(message),
         parse_mode=None,
         reply_to=reply_to,
     )
@@ -1015,6 +1039,7 @@ def setup() -> None:
         f"BRIDGE_TOKEN={token}\n"
         "TELEGRAM_ENABLED=true\n"
         "NEW_TOPIC_PER_CAPTURE=false\n"
+        "DELIVERY_CONTEXT=conversation\n"
         f"ASSISTANT_CHAT={chat}\n"
         f"ASSISTANT_NAME={name}\n"
         f"TG_API_ID={api_id}\n"

--- a/tests/test_topic_delivery.py
+++ b/tests/test_topic_delivery.py
@@ -55,6 +55,7 @@ def routing(entity, **extra_entities):
         DEFAULT_ASSISTANT="assistant",
         ASSISTANT_ROSTER=roster,
         assistant_entities=entities,
+        DELIVERY_CONTEXT="conversation",
     )
 
 
@@ -79,6 +80,36 @@ class ConfigurationTests(unittest.TestCase):
             self.assertEqual(
                 ringbearer.delivery_mode_label(), "current Telegram conversation"
             )
+
+
+class DeliveryContextTests(unittest.TestCase):
+    def test_conversation_context_preserves_existing_message_shape(self):
+        with patch.multiple(
+            ringbearer, DELIVERY_CONTEXT="conversation", RING_PREFIX="mic: "
+        ):
+            self.assertEqual(ringbearer.format_delivery_message("hello"), "mic: hello")
+
+    def test_one_shot_context_explains_the_noninteractive_contract(self):
+        with patch.multiple(
+            ringbearer, DELIVERY_CONTEXT="one_shot", RING_PREFIX="mic: "
+        ):
+            formatted = ringbearer.format_delivery_message("send the report")
+
+        self.assertTrue(formatted.startswith("mic: [RING CAPTURE: ONE-SHOT]"))
+        self.assertIn("may not see any reply", formatted)
+        self.assertIn("execute it now without asking for confirmation", formatted)
+        self.assertIn("Resolve minor ambiguity", formatted)
+        self.assertIn("leave a concise blocker", formatted)
+        self.assertTrue(formatted.endswith("Transcript:\nsend the report"))
+
+    def test_one_shot_context_preserves_transcript_verbatim(self):
+        transcript = "  Keep *this* exactly.\nSecond line [still literal].  "
+        with patch.multiple(
+            ringbearer, DELIVERY_CONTEXT="one_shot", RING_PREFIX="mic: "
+        ):
+            formatted = ringbearer.format_delivery_message(transcript)
+
+        self.assertEqual(formatted.split("Transcript:\n", 1)[1], transcript)
 
 
 class ParseAssistantsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add an opt-in `DELIVERY_CONTEXT=one_shot` mode for non-interactive ring captures
- wrap the verbatim transcript in recipient-side guidance to act without waiting for confirmation or follow-up
- preserve the existing message shape under the default `conversation` mode
- document the safety boundary: use low-risk defaults, but leave a concise blocker when essential information is missing or an action is materially unsafe or irreversible
- keep local capture logging and topic titles based on the raw transcript

## Motivation

A user speaking through an Index 01 may not see the assistant's reply. A normal assistant response can therefore dead-end on a confirmation or clarification question. The MCP prompt cannot solve this because it governs Pebble's relay agent, not the final assistant receiving the Telegram message.

The new mode carries that interaction context across the Telegram boundary while remaining opt-in and assistant-agnostic.

## Testing

- `.venv/bin/python -m unittest -v` (47 tests pass)
- `.venv/bin/python -m compileall -q ringbearer.py tests`
- live service restarted with `DELIVERY_CONTEXT=one_shot`
- `/healthz` returned HTTP 200 with Telegram connection state `up`
